### PR TITLE
Rework DayNight - reduce object creation

### DIFF
--- a/src/dayNightSystem/dayNightClock.mjs
+++ b/src/dayNightSystem/dayNightClock.mjs
@@ -6,13 +6,17 @@
 // note: don't run more than one day/night clock at a time.  doing so will cause multiple
 //       filters to be applied to the screen, which won't look too nice. :o)
 
-import { Prim, Thread } from 'sphere-runtime';
+import { Thread } from 'sphere-runtime';
 
 import InGameTime from './inGameTime';
 
-const DayMask = Color.Transparent,
-      TwilightMask = new Color(0.5, 0.125, 0.0625, 0.625),
-      NightMask = new Color(0.0, 0.0, 0.125, 0.5625);
+const DayMask    = [ 0.0, 0.0, 0.0, 0.0 ],
+	TwilightMask = [ 0.5, 0.125, 0.0625, 0.625 ],
+	NightMask    = [ 0.0, 0.0, 0.125, 0.5625 ];
+
+const Day  = 0,
+	Night  = 1,
+	Fading = 2;
 
 export default
 class DayNightClock extends Thread
@@ -21,54 +25,84 @@ class DayNightClock extends Thread
 	{
 		super({ priority: 1 });
 
+		let width = Surface.Screen.width;
+		let height = Surface.Screen.height;
+		let rectangle = new Shape(ShapeType.TriStrip,
+			new VertexList([
+				{ x: 0,     y: 0 },
+				{ x: width, y: 0 },
+				{ x: 0,     y: height },
+				{ x: width, y: height },
+			]));
+		this.shader = new Shader({
+			fragmentFile: '#/shaders/image.frag.glsl',
+			vertexFile  : '#/shaders/image.vert.glsl',
+		});
+		this.model = new Model ([ rectangle ], this.shader);
+
+		this.inGameTime = new InGameTime(0, 0, 0);
+		this.offset = new Date().getTimezoneOffset() * 60 * 1000;
+		this.state = Day;
+		this.currentMask = [ 0.0, 0.0, 0.0, 0.0 ];
+
+		this.on_update();
 		console.log("initializing day/night clock", `time: ${this.now()}`);
-		this.currentMask = Color.Transparent;
 		this.start();
 	}
 
 	now()
 	{
-		let realTime = new Date();
-		let currentTime = 3600 * realTime.getHours() + 60 * realTime.getMinutes() + realTime.getSeconds();
-		currentTime = (currentTime * 10) % 86400;
-		let hour = Math.floor(currentTime / 3600);
-		let minute = Math.floor((currentTime / 60) % 60);
-		let second = currentTime % 60;
-		return new InGameTime(hour, minute, second);
+		const time = Math.floor((Date.now() - this.offset) * 0.001) % 86400;
+		const currentTime = ((time * 10) % 86400);
+		this.inGameTime.hour = Math.floor(currentTime / 3600);
+		this.inGameTime.minute = Math.floor((currentTime / 60) % 60);
+		this.inGameTime.second = currentTime % 60;
+		return this.inGameTime;
 	}
 
 	on_render()
 	{
-		Prim.fill(Surface.Screen, this.currentMask);
+		this.model.draw();
+	}
+
+	mixMasks(mask1, mask2, proportion1, proportion2)
+	{
+		this.currentMask[0] = mask1[0] * proportion1 + mask2[0] * proportion2;
+		this.currentMask[1] = mask1[1] * proportion1 + mask2[1] * proportion2;
+		this.currentMask[2] = mask1[2] * proportion1 + mask2[2] * proportion2;
+		this.currentMask[3] = mask1[3] * proportion1 + mask2[3] * proportion2;
+		this.shader.setFloatVector('tintColor', this.currentMask);
 	}
 
 	on_update()
 	{
 		let now = this.now();
 		if (now.hour < 5 || now.hour >= 19) {
-			this.currentMask = NightMask;
+			if (this.state !== Night) {
+				this.state = Night;
+				this.shader.setFloatVector('tintColor', NightMask);
+			}
 		} else if (now.hour >= 7 && now.hour < 17) {
-			this.currentMask = DayMask;
+			if (this.state !== Day) {
+				this.state = Day;
+				this.shader.setFloatVector('tintColor', DayMask);
+			}
 		} else if (now.hour >= 5 && now.hour < 6) {
-			let fromMask = NightMask;
-			let toMask = TwilightMask;
+			this.state = Fading;
 			let alpha = now.minute / 60;
-			this.currentMask = Color.mix(toMask, fromMask, alpha, 1.0 - alpha);
+			this.mixMasks(TwilightMask, NightMask, alpha, 1.0 - alpha);
 		} else if (now.hour >= 6 && now.hour < 7) {
-			let fromMask = TwilightMask;
-			let toMask = DayMask;
+			this.state = Fading;
 			let alpha = now.minute / 60;
-			this.currentMask = Color.mix(toMask, fromMask, alpha, 1.0 - alpha);
+			this.mixMasks(DayMask, TwilightMask, alpha, 1.0 - alpha);
 		} else if (now.hour >= 17 && now.hour < 18) {
-			let fromMask = DayMask;
-			let toMask = TwilightMask;
+			this.state = Fading;
 			let alpha = now.minute / 60;
-			this.currentMask = Color.mix(toMask, fromMask, alpha, 1.0 - alpha);
+			this.mixMasks(TwilightMask, DayMask, alpha, 1.0 - alpha);
 		} else if (now.hour >= 18 && now.hour < 19) {
-			let fromMask = TwilightMask;
-			let toMask = NightMask;
+			this.state = Fading;
 			let alpha = now.minute / 60;
-			this.currentMask = Color.mix(toMask, fromMask, alpha, 1.0 - alpha);
+			this.mixMasks(NightMask, TwilightMask, alpha, 1.0 - alpha);
 		}
 	}
 }


### PR DESCRIPTION
This isn't as pretty but it is functionally identical, faster and doesn't generate and discard objects - therefore reduces GC pressure.

Significant changes:
1. Do the colours with a model and a shader (gets rid of Prim use and no Colour.mix object creation)

2. Use Date.now() instead of new date - gives milliseconds since 1st Jan 1970 - considering the intent is time in an individual day effect is the same and doesn't instantiate an object